### PR TITLE
gem の line-bot-api を追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ gem 'jbuilder', '~> 2.7'
 
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.4.2', require: false
+gem 'line-bot-api'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,6 +83,7 @@ GEM
       concurrent-ruby (~> 1.0)
     jbuilder (2.10.1)
       activesupport (>= 5.0.0)
+    line-bot-api (1.16.0)
     listen (3.3.3)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -211,6 +212,7 @@ DEPENDENCIES
   byebug
   capybara (>= 2.15)
   jbuilder (~> 2.7)
+  line-bot-api
   listen (~> 3.2)
   mysql2 (>= 0.4.4, < 0.6.0)
   pry-byebug

--- a/app/controllers/line_bot_controller.rb
+++ b/app/controllers/line_bot_controller.rb
@@ -1,5 +1,38 @@
 class LineBotController < ApplicationController
+  require "line/bot"
+
+  protect_from_forgery with: :null_session
+
   def callback
-    binding.pry
+    # LINEで送られてきたメッセージのデータを取得
+    body = request.body.read
+
+    # LINE以外からリクエストが来た場合 Error を返す
+    signature = request.env["HTTP_X_LINE_SIGNATURE"]
+    unless client.validate_signature(body, signature)
+      head :bad_request and return
+    end
+
+    # LINEで送られてきたメッセージを適切な形式に変形
+    events = client.parse_events_from(body)
+
+    events.each do |event|
+      # LINE からテキストが送信された場合
+      if (event.type === Line::Bot::Event::MessageType::Text)
+        # LINE からテキストが送信されたときの処理を記述する
+      end
+    end
+
+    # LINE の webhook API との連携をするために status code 200 を返す
+    render json: { status: :ok }
   end
+
+  private
+
+    def client
+      @client ||= Line::Bot::Client.new do |config|
+        config.channel_secret = ENV["LINE_CHANNEL_SECRET"]
+        config.channel_token = ENV["LINE_CHANNEL_TOKEN"]
+      end
+    end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -59,4 +59,7 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
+  # ngrok を立ち上げた際に発行される URL のドメイン部分（https:// 以降)を以下のように記載する
+  config.hosts = ["4153d8339c2f.ngrok.io", "localhost"]
 end


### PR DESCRIPTION
## 概要
- ngrok を brew cask install
- line_bot_controller.rb に追記